### PR TITLE
Chown for folder permissions

### DIFF
--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -157,7 +157,7 @@ class SLKFile(io.IOBase):
             return
         components = Path(rp).parts[1:]
         for i in range (len(components)):
-            subpath = Path(*components[:i+1])
+            subpath = Path("/", *components[:i+1])
             if not os.access(subpath, os.F_OK):
                 os.mkdir(subpath)
                 os.chmod(subpath, self.file_permissions)

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -57,7 +57,7 @@ class SLKFile(io.IOBase):
         'r'       open for reading (default)
         'b'       binary mode (default)
         't'       text mode
-    file_permissions: int, default 0o3777
+    file_permissions: int, default 0o3775
         Permission when creating directories and files.
     **kwargs:
         Additional keyword arguments passed to the open file descriptor method.
@@ -91,7 +91,7 @@ class SLKFile(io.IOBase):
         override: bool = True,
         mode: str = "rb",
         touch: bool = True,
-        file_permissions: int = 0o3777,
+        file_permissions: int = 0o3775,
         _lock: threading.Lock = _retrieval_lock,
         _file_queue: Queue[Tuple[str, str]] = FileQueue,
         **kwargs: Any,
@@ -251,7 +251,7 @@ class SLKFileSystem(AbstractFileSystem):
         retrieve data from tape.
     block_size: int, default: None
          Some indication of buffering - this is a value in bytes
-    file_permissions: int, default: 0o3777
+    file_permissions: int, default: 0o3775
         Permission when creating directories and files.
     override: bool, default: False
         Override existing files
@@ -269,7 +269,7 @@ class SLKFileSystem(AbstractFileSystem):
         self,
         block_size: Optional[int] = None,
         slk_cache: Optional[Union[str, Path]] = None,
-        file_permissions: int = 0o3777,
+        file_permissions: int = 0o3775,
         touch: bool = True,
         override: bool = False,
         **storage_options: Any,


### PR DESCRIPTION
the pure mkdir() ignores our requests for the sticky bit.


```
from pathlib import Path
import os
def genp( end) : 
    return Path(f"/scratch/k/k202134/test_pathlib-{end}/")
pts = dict (pure = genp("pure"),
             perm = genp("perm"),
             umask = genp("umask"),
             chown = genp("chown"),
            )
for p in pts.values():
    try: 
        p.rmdir()
    except:
        print ('cannot rmdir ', p)

        
pts['pure'].mkdir()

pts['perm'].mkdir(mode=0o3775)

oldmask = os.umask(0)
pts['umask'].mkdir(mode=0o3775)
os.umask(oldmask)

def mkdirs(file_permissions, path):
        rp = os.path.realpath(path)
        if os.access(rp, os.F_OK):
            print("already there")
            return
        components = Path(rp).parts[1:]
        for i in range (len(components)):
            subpath = Path('/', *components[:i+1])
            if not os.access(subpath, os.R_OK):
                os.mkdir(subpath)
                os.chmod(subpath, file_permissions)

mkdirs(0o3775, pts['chown'])
!ls -dl {genp ('*')}
```
yields
```
drwxrwsr-t 2 k202134 k20200 4096 Feb  7 10:18 /scratch/k/k202134/test_pathlib-chown
drwxr-xr-t 2 k202134 k20200 4096 Feb  7 10:18 /scratch/k/k202134/test_pathlib-perm
drwxr-xr-x 2 k202134 k20200 4096 Feb  7 10:18 /scratch/k/k202134/test_pathlib-pure
drwxrwxr-t 2 k202134 k20200 4096 Feb  7 10:18 /scratch/k/k202134/test_pathlib-umask
```