### PR TITLE
update pyslk calls to pyslk 1.8.0

### DIFF
--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -332,7 +332,7 @@ class SLKFileSystem(AbstractFileSystem):
                information dicts if detail is True.
         """
         path = Path(path)
-        filelist = pyslk.list(str(path)).split("\n")
+        filelist = pyslk.slk_list(str(path)).split("\n")
         detail_list: List[FileInfo] = []
         types = {"d": "directory", "-": "file"}
         for file_entry in filelist[:-2]:

--- a/slkspec/tests/conftest.py
+++ b/slkspec/tests/conftest.py
@@ -20,7 +20,7 @@ class SLKMock:
     def __init__(self, _cache: dict[int, list[str]] = {}) -> None:
         self._cache = _cache
 
-    def slk_list(self, inp_path: str) -> str:
+    def list(self, inp_path: str) -> str:
         """Mock the slk_list method."""
         res = (
             run(["ls", "-l", inp_path], stdout=PIPE, stderr=PIPE)
@@ -29,13 +29,13 @@ class SLKMock:
         )
         return "\n".join(res[1:] + [res[0]])
 
-    def slk_search(self, inp_f: list[str]) -> str:
+    def search(self, inp_f: list[str]) -> int:
         """Mock slk_search."""
         if not inp_f:
-            return ""
+            return None
         hash_value = abs(hash(",".join(inp_f)))
         self._cache[hash_value] = inp_f
-        return f"Search ID: {hash_value} foo"
+        return hash_value
 
     def slk_gen_file_query(self, inp_files: list[str]) -> list[str]:
         """Mock slk_gen_file_qeury."""

--- a/slkspec/tests/conftest.py
+++ b/slkspec/tests/conftest.py
@@ -1,6 +1,7 @@
 """pytest definitions to run the unittests."""
 from __future__ import annotations
 
+import builtins
 import shutil
 from pathlib import Path
 from subprocess import PIPE, run
@@ -17,7 +18,7 @@ import xarray as xr
 class SLKMock:
     """A mock that emulates what pyslk is doing."""
 
-    def __init__(self, _cache: dict[int, list[str]] = {}) -> None:
+    def __init__(self, _cache: dict[int, builtins.list[str]] = {}) -> None:
         self._cache = _cache
 
     def list(self, inp_path: str) -> str:
@@ -29,7 +30,7 @@ class SLKMock:
         )
         return "\n".join(res[1:] + [res[0]])
 
-    def search(self, inp_f: list[str]) -> int:
+    def search(self, inp_f: builtins.list[str]) -> int | None:
         """Mock slk_search."""
         if not inp_f:
             return None
@@ -37,7 +38,7 @@ class SLKMock:
         self._cache[hash_value] = inp_f
         return hash_value
 
-    def slk_gen_file_query(self, inp_files: list[str]) -> list[str]:
+    def slk_gen_file_query(self, inp_files: builtins.list[str]) -> builtins.list[str]:
         """Mock slk_gen_file_qeury."""
         return [f for f in inp_files if Path(f).exists()]
 

--- a/slkspec/tests/conftest.py
+++ b/slkspec/tests/conftest.py
@@ -21,7 +21,7 @@ class SLKMock:
     def __init__(self, _cache: dict[int, builtins.list[str]] = {}) -> None:
         self._cache = _cache
 
-    def list(self, inp_path: str) -> str:
+    def slk_list(self, inp_path: str) -> str:
         """Mock the slk_list method."""
         res = (
             run(["ls", "-l", inp_path], stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
- changing to newer pyslk functions
- using `pyslk.search` which returns the search id as an integer
- adapt SLKmock