### PR TITLE
Remove loop over retrieval directories

### DIFF
--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -6,7 +6,6 @@ import os
 import threading
 import time
 import warnings
-from collections import defaultdict
 from getpass import getuser
 from pathlib import Path
 from queue import Queue
@@ -46,6 +45,9 @@ class SLKFile(io.IOBase):
         Source path of the file that should be retrieved.
     local_file: str
         Destination path of the downloaded file.
+    slk_cache: str | Path
+        Destination of the temporary storage. This directory is used to
+        retrieve data from tape.
     override: bool, default: False
         Override existing files
     touch: bool, default: True
@@ -86,7 +88,7 @@ class SLKFile(io.IOBase):
         self,
         url: str,
         local_file: str,
-        slk_cache: str,
+        slk_cache: Union[str, Path],
         *,
         override: bool = True,
         mode: str = "rb",
@@ -103,7 +105,7 @@ class SLKFile(io.IOBase):
             kwargs.setdefault("encoding", "utf-8")
         self._file = str(Path(local_file).expanduser().absolute())
         self._url = str(url)
-        self.slk_cache = str(slk_cache)
+        self.slk_cache = Path(slk_cache)
         self.touch = touch
         self.file_permissions = file_permissions
         self._order_num = 0
@@ -136,24 +138,20 @@ class SLKFile(io.IOBase):
     def _retrieve_items(self, retrieve_files: list[tuple[str, str]]) -> None:
         """Get items from the tape archive."""
 
-        retrieval_requests: Dict[Path, List[str]] = defaultdict(list)
-        import ipdb
-
-        ipdb.set_trace()
+        retrieval_requests: List[str] = list()
         logger.debug("Retrieving %i items from tape", len(retrieve_files))
-        # for inp_file, out_dir in retrieve_files:
-        #    retrieval_requests[Path(out_dir)].append(inp_file)
-        # for output_dir, inp_files in retrieval_requests.items():
-        #    output_dir.mkdir(parents=True, exist_ok=True, mode=self.file_permissions)
+        for inp_file, _ in retrieve_files:
+            retrieval_requests.append(inp_file)
         logger.debug("Creating slk query for %i files", len(retrieve_files))
-        search_id = pyslk.search(pyslk.slk_gen_file_query(inp_files))
+        search_id = pyslk.search(pyslk.slk_gen_file_query(retrieval_requests))
         if search_id is None:
             raise FileNotFoundError("No files found in archive.")
         logger.debug("Retrieving files for search id: %i", search_id)
-        pyslk.slk_retrieve(search_id, self.slk_cache)
-        # logger.debug("Adjusting file permissions")
-        #    for out_file in map(Path, inp_files):
-        #        (output_dir / out_file.name).chmod(self.file_permissions)
+        pyslk.slk_retrieve(search_id, self.slk_cache, preserve_path=True)
+        logger.debug("Adjusting file permissions")
+        for out_file in retrieval_requests:
+            local_path = self.slk_cache / Path(out_file.strip("/"))
+            local_path.chmod(self.file_permissions)
 
     def _cache_files(self) -> None:
         time.sleep(self.delay)
@@ -365,6 +363,7 @@ class SLKFileSystem(AbstractFileSystem):
         return SLKFile(
             str(path),
             str(local_path),
+            self.slk_cache,
             mode=mode,
             override=self.override,
             touch=self.touch,

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -147,7 +147,7 @@ class SLKFile(io.IOBase):
         if search_id is None:
             raise FileNotFoundError("No files found in archive.")
         logger.debug("Retrieving files for search id: %i", search_id)
-        pyslk.slk_retrieve(search_id, self.slk_cache, preserve_path=True)
+        pyslk.slk_retrieve(search_id, str(self.slk_cache), preserve_path=True)
         logger.debug("Adjusting file permissions")
         for out_file in retrieval_requests:
             local_path = self.slk_cache / Path(out_file.strip("/"))

--- a/slkspec/tests/conftest.py
+++ b/slkspec/tests/conftest.py
@@ -42,10 +42,15 @@ class SLKMock:
         """Mock slk_gen_file_qeury."""
         return [f for f in inp_files if Path(f).exists()]
 
-    def slk_retrieve(self, search_id: int, out_dir: str) -> None:
+    def slk_retrieve(self, search_id: int, out_dir: str, preserve_path: bool) -> None:
         """Mock slk_retrieve."""
         for inp_file in map(Path, self._cache[search_id]):
-            shutil.copy(inp_file, Path(out_dir) / inp_file.name)
+            if preserve_path:
+                outfile = Path(out_dir) / Path(str(inp_file).strip(inp_file.root))
+                outfile.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(inp_file, outfile)
+            else:
+                shutil.copy(inp_file, Path(out_dir) / inp_file.name)
 
 
 def create_data(variable_name: str, size: int) -> xr.Dataset:


### PR DESCRIPTION
Combines retrievals across directories into one:

```python
import fsspec; import xarray as xr
m=fsspec.open_files(["slk:///arch/mh0010/m300408/showcase/dataset2/dataset2.nc", "slk:///arch/mh0010/m300408/showcase/dataset1/dataset1.nc"])
with m as f:
     ds = xr.open_mfdataset(f, engine="h5netcdf")
```
The logging shows for **the current implementation**
```
/scratch/m/m300408/arch/mh0010/m300408/showcase/dataset2/dataset2.nc
/scratch/m/m300408/arch/mh0010/m300408/showcase/dataset1/dataset1.nc
2023-02-17 09:41:44,578 - slkspec - DEBUG - Retrieving 2 items from tape
2023-02-17 09:41:44,579 - slkspec - DEBUG - Creating slk query for 1 files
2023-02-17 09:41:51,403 - slkspec - DEBUG - Retrieving files for search id: 311038
2023-02-17 09:41:58,613 - slkspec - DEBUG - Adjusting file permissions
2023-02-17 09:41:58,614 - slkspec - DEBUG - Creating slk query for 1 files
2023-02-17 09:42:05,729 - slkspec - DEBUG - Retrieving files for search id: 311039
2023-02-17 09:42:12,169 - slkspec - DEBUG - Adjusting file permissions
```
And after **this PR**:
```
/scratch/m/m300408/arch/mh0010/m300408/showcase/dataset2/dataset2.nc
/scratch/m/m300408/arch/mh0010/m300408/showcase/dataset1/dataset1.nc
2023-02-17 09:47:10,392 - slkspec - DEBUG - Retrieving 2 items from tape
2023-02-17 09:47:10,418 - slkspec - DEBUG - Creating slk query for 2 files
2023-02-17 09:47:30,653 - slkspec - DEBUG - Retrieving files for search id: 311043
2023-02-17 09:47:46,123 - slkspec - DEBUG - Adjusting file permissions
```