### PR TITLE
Drop python 3.7 and 3.8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
         max-parallel: 5
         matrix:
-          python-version: [3.8, 3.9, "3.10", "3.11"]
+          python-version: [3.9, "3.10", "3.11"]
 
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=[
         "fsspec>=0.9.0",
         "pyslk @ git+https://gitlab.dkrz.de/hsm-tools/pyslk.git@master",


### PR DESCRIPTION
pyslk does no longer support python <=3.8