### PR TITLE
depends on pyslk 2.3.0; improved recall workflow; reduce API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.4
+- incremented dependency on ``pyslk`` to ``2.3.0`` => improved workflows + new required functions
+- internal ``list`` of files needed to be retrieved was changed to type ``set`` => remove duplicate files
+- consider case when files are copied to the cache by another process while they are queued for being recalled from tape to cache by this instance of slkspec
+- split recall and retrieval code into more sub-functions for clearer code structure
+
 ## v0.0.3
 - adapted to ``pyslk`` version >= 2.0.0
 - improved and parallelized retrieval workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "fsspec>=0.9.0",
-  "pyslk>=2.2.9",
+  "pyslk>=2.3.0",
 ]
 
 [project.entry-points."fsspec.specs"]

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -1101,7 +1101,7 @@ class SLKRetrieval:
                 output_dry_retrieve = pyslk.retrieve_improved(
                     inp_file, out_dir, dry_run=True, preserve_path=False
                 )
-                self._eval_output_dry_retrieval(
+                retrieve_counter = self._eval_output_dry_retrieval(
                     output_dry_retrieve,
                     inp_file,
                     out_dir,
@@ -1112,10 +1112,10 @@ class SLKRetrieval:
             self.files_retrieval_requested.remove(inp_file)
             self.files_retrieval_succeeded.add(str(inp_file))
 
-        if retrieve_counter == 0:
+        if len(self.files_retrieval_succeeded) == 0:
             logger.info("No files retrieved")
         else:
-            logger.info(f"{retrieve_counter} files retrieved")
+            logger.info(f"{len(self.files_retrieval_succeeded)} files retrieved")
 
     def _eval_output_dry_retrieval(
         self,
@@ -1124,7 +1124,7 @@ class SLKRetrieval:
         out_dir: str,
         retrieve_counter: int,
         files_retrieval_done: set,
-    ) -> None:
+    ) -> int:
         # example output of pyslk.retrieve_improved:
         """
         {
@@ -1188,7 +1188,7 @@ class SLKRetrieval:
                 self.files_retrieval_reasonable.remove(inp_file)
                 files_retrieval_done.add(inp_file)
                 retrieve_counter = retrieve_counter + 1
-                return
+                return retrieve_counter
 
         # check if file should be skipped
         if "SKIPPED" in output_retrieve:
@@ -1218,6 +1218,7 @@ class SLKRetrieval:
                 + f"{json.dumps(output_retrieve)}"
             )
             self.files_retrieval_reasonable.remove(inp_file)
+        return retrieve_counter
 
 
 def _write_file_lists(

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -173,9 +173,8 @@ class SLKFile(io.IOBase):
         files_retrieval_failed: dict[str, str] = dict()
         # start
         logger.debug(
-            "Retrieving %i items from tape (%i already available)",
+            "Planning to retrieve %i items from cache/tape",
             len(retrieve_files_corrected),
-            len(retrieve_files) - len(retrieve_files_corrected),
         )
         # instantiate recall and retrieval classes
         slk_recall: SLKRecall = SLKRecall(retrieve_files_corrected)


### PR DESCRIPTION
- incremented dependency on ``pyslk`` to ``2.3.0`` => improved workflows + new required functions
- internal ``list`` of files needed to be retrieved was changed to type ``set`` => remove duplicate files
- consider case when files are copied to the cache by another process while they are queued for being recalled from tape to cache by this instance of slkspec
- split recall and retrieval code into more sub-functions for clearer code structure