### PR TITLE
adapt slkspec to new HSM proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,3 @@ report.xml
 
 # IDEs
 .idea
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.5
+- a few new debugging logging messages
+- improved way to set logging level for ``slkspec``
+
 ## v0.0.4
 - incremented dependency on ``pyslk`` to ``2.3.0`` => improved workflows + new required functions
 - internal ``list`` of files needed to be retrieved was changed to type ``set`` => remove duplicate files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.0
+- switched to new ``hsm`` package and recall/HSM proxy for starting and organizing recalls
+- considerably simplified code basis in the context of switching to the HSM proxy
+- default delay for the queue to collect resources is set from 2 to 5 seconds
+
 ## v0.0.5
 - a few new debugging logging messages
 - improved way to set logging level for ``slkspec``

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ import fsspec
 with fsspec.open("slk:///arch/project/user/file", "r") as f:
     print(f.read())
 ```
-### Loading datasets
+
+## Loading datasets
+
+### one file without manual creation of a filesystem
 
 ```python
 
@@ -24,6 +27,33 @@ url = fsspec.open("slk:////arch/project/file.nc", slk_cache="/scratch/b/b12346")
 dset = xr.open_dataset(url)
 ```
 
+### one file with manual creation of a filesystem
+
+```python
+
+import ffspec
+import xarray as xr
+
+fs = fsspec.filesystem('slk')
+f = fs.open('slk:///arch/bm0146/k204221/testing/testing05/test01.nc')
+ds = xr.open_dataset(f)
+```
+
+### multiple files
+
+```python
+
+import ffspec
+import xarray as xr
+
+fs = fsspec.filesystem('slk')
+my_files = [
+        'slk:///arch/bm0146/k204221/testing/testing14/test_netcdf_01.nc',
+        'slk:///arch/bm0146/k204221/testing/testing11/test_netcdf_a.nc',
+        'slk:///arch/bm0146/k204221/testing/testing05/test01.nc'
+]
+ds = xr.open_mfdataset([fs.open(f)  for f in my_files])
+```
 
 ## Usage in combination with preffs
 ### Installation of additional requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ ignore_missing_imports = true
 [tool.mypy-pyslk]
 ignore_missing_imports = true
 
+[tool.mypy-hsm]
+ignore_missing_imports = true
+
 [tool.setuptools.packages]
 find = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ ignore_missing_imports = true
 [tool.mypy-hsm]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["hsm"]
+ignore_missing_imports = true
+
 [tool.setuptools.packages]
 find = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "fsspec implementation for StrongLink tape archive"
 readme = "README.md"
 license = {text = "MIT License"}
-authors = [{name = "Hauke Schulz", email = "haschulz@uw.edu"}]
+authors = [{name = "Hauke Schulz", email = "has@dmi.dk"}]
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -30,7 +30,11 @@ import pyslk
 from fsspec.spec import AbstractFileSystem
 
 logger = logging.getLogger("slkspec")
-logger.setLevel(logging.INFO)
+if logger.level == 0:
+    if logging.root.level == 0:
+        logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.root.level)
 
 MAX_RETRIES = 2
 MAX_PARALLEL_RECALLS = 3
@@ -1230,6 +1234,14 @@ def _write_file_lists(
         and file_path not in slk_retrieval.files_retrieval_failed.keys()
     ]
     tmp_str: str
+    logger.debug(
+        "Start writing file lists if one of these values is larger than 0: "
+        + "#'files retrieval reasonable' is "
+        + f"{len(slk_retrieval.files_retrieval_reasonable)}; #'files recall "
+        + f"failed' is {len(slk_recall.files_recall_failed.keys())}; #'files "
+        + "retrieval failed' is "
+        + f"{len(slk_retrieval.files_retrieval_failed.keys())}"
+    )
     if (
         len(slk_retrieval.files_retrieval_reasonable) > 0
         or len(slk_recall.files_recall_failed.keys()) > 0
@@ -1246,12 +1258,20 @@ def _write_file_lists(
             + f"in directory '{str(slk_cache)}'."
         )
         if len(slk_recall.files_recall_failed) > 0:
+            logger.debug(
+                "Write list of files which recall failed into "
+                + f"{os.path.join(slk_cache, file_failed_recall)}"
+            )
             tmp_str = "\n  ".join(slk_recall.files_recall_failed)
             logger.error(f"files, recall failed:\n  {tmp_str}")
             with open(os.path.join(slk_cache, file_failed_recall), "w") as f:
                 for file_path, reason in slk_recall.files_recall_failed.items():
                     f.write(f"{file_path}: {reason}\n")
         if len(slk_retrieval.files_retrieval_failed) > 0:
+            logger.debug(
+                "Write list of files which retrieval failed into "
+                + f"{os.path.join(slk_cache, file_failed_retrieve)}"
+            )
             tmp_str = "\n  ".join(slk_retrieval.files_retrieval_failed)
             logger.error(f"files, retrieval failed (recall successful):\n  {tmp_str}")
             with open(os.path.join(slk_cache, file_failed_retrieve), "w") as f:
@@ -1261,6 +1281,10 @@ def _write_file_lists(
                 ) in slk_retrieval.files_retrieval_failed.items():
                     f.write(f"{file_path}: {reason}\n")
         if len(missing_files) > 0:
+            logger.debug(
+                "Write list of files which were not retrieved for other "
+                + f"reasons to {os.path.join(slk_cache, file_failed_other)}"
+            )
             tmp_str = "\n  ".join(missing_files)
             logger.error(f"files, missing for other reasons:\n  {tmp_str}")
             with open(os.path.join(slk_cache, file_failed_other), "w") as f:

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -118,7 +118,7 @@ class SLKFile(io.IOBase):
         touch: bool = False,
         file_permissions: int = 0o644,
         dir_permissions: int = 0o3775,
-        delay: int = 2,
+        delay: int = 5,
         _lock: threading.Lock = _retrieval_lock,
         _file_queue: Queue[Tuple[str, str]] = FileQueue,
         **kwargs: Any,

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -38,11 +38,11 @@ if logger.level == 0:
     else:
         logger.setLevel(logging.root.level)
 
-
-MAX_RETRIES = 2
-MAX_PARALLEL_RECALLS = 3
-MAX_RETRIES_RECALL = 3
+# default delay for the queue to collect resources: 5 seconds
+default_queue_delay = 5
+# define queue
 FileQueue: Queue[Tuple[str, str]] = Queue(maxsize=-1)
+# other definitions
 FileInfo = TypedDict("FileInfo", {"name": str, "size": int, "type": str})
 TapeGroup = TypedDict(
     "TapeGroup",
@@ -121,7 +121,7 @@ class SLKFile(io.IOBase):
         touch: bool = False,
         file_permissions: int = 0o644,
         dir_permissions: int = 0o3775,
-        delay: int = 5,
+        delay: int = default_queue_delay,
         _lock: threading.Lock = _retrieval_lock,
         _file_queue: Queue[Tuple[str, str]] = FileQueue,
         **kwargs: Any,
@@ -372,7 +372,7 @@ class SLKFileSystem(AbstractFileSystem):
         file_permissions: int = 0o644,
         dir_permissions: int = 0o3775,
         touch: bool = False,
-        delay: int = 2,
+        delay: int = default_queue_delay,
         override: bool = False,
         **storage_options: Any,
     ):

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -831,11 +831,9 @@ def _write_file_lists(
     )
     tmp_str: str
     logger.debug(
-        "Start writing file lists if one of these values is larger than 0: "
-        + "#'files retrieval reasonable' is "
-        + f"{len(slk_retrieval.files_retrieval_reasonable)}; #'files recall "
-        + f"failed' is {len(slk_recall.files_recall_failed.keys())}; #'files "
-        + "retrieval failed' is "
+        "Start writing file lists if one of these values is larger than 0: #'files "
+        + f"retrieval reasonable' is {len(files_not_retrieved_yet)}; #'files recall "
+        + f"failed' is {len(files_recall_failed)}; #'files retrieval failed' is "
         + f"{len(slk_retrieval.files_retrieval_failed.keys())}"
     )
     if (

--- a/slkspec/core.py
+++ b/slkspec/core.py
@@ -919,7 +919,7 @@ class SLKRecall:
     def _check_tapes_of_split_file_available(
         self, file_id: int, tmp_tapes: list[str]
     ) -> list[bool]:
-        tmp_tapes_available: List[bool]
+        tmp_tapes_available: List[bool] = list()
         msg: str
         for tape in tmp_tapes:
             # go through tape list and start new recalls

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,5 @@
 # mypy: ignore-errors
+# flake8: noqa
 # Version: 0.21
 
 """The Versioneer - like a rocketeer, but for versions.


### PR DESCRIPTION
- switched to new ``hsm`` package and recall/HSM proxy for starting and organizing recalls
- considerably simplified code basis in the context of switching to the HSM proxy

This is for release 0.1.0 or similar. This PR contains breaking changes. It requires a package `hsm` which is still undergoing a test phase at DKRZ.